### PR TITLE
Update with the latest tyxml

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -25,7 +25,7 @@ Library html
   FindlibParent: markdown
   Path:          src
   Modules:       MarkdownHTML
-  BuildDepends:  markdown, tyxml
+  BuildDepends:  markdown, tyxml (>= 3.0)
 
 Executable test
   Path:         test

--- a/src/MarkdownHTML.ml
+++ b/src/MarkdownHTML.ml
@@ -52,7 +52,7 @@ let to_html ~render_pre ~render_link ~render_img l =
 
 end
 
-module Make_html5 (Html5 : Html5_sigs.T) = struct
+module Make_html5 (Html5 : Html5_sigs.T with type 'a Xml.wrap = 'a and type 'a wrap = 'a) = struct
 
 open Markdown
 open Html5


### PR DESCRIPTION
I don't know if it's reasonable to merge it now but at least it's there.
So tyxml since some minutes ago change a bit its interface (in ocsigen/tyxml#14) and now has this `wrap` type almost everywhere. I don't know how to fix it without breaking the backward compatibility.
